### PR TITLE
Switch to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Use `prepublishOnly` instead of `prepublish`. Mostly just forcing a new release